### PR TITLE
docs: warn about quoting .env values containing special characters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Epic account
+# If a value contains $, \, #, or ` (e.g. some passwords), wrap it in single
+# quotes so python-dotenv keeps it as a literal: EPIC_PASSWORD='abc$def'.
+# This only affects local .env files; GitHub Actions Secrets are unaffected.
 EPIC_EMAIL=xxxx@qq.com
 EPIC_PASSWORD=mypassword
 

--- a/README.en.md
+++ b/README.en.md
@@ -220,6 +220,9 @@ If you want to reproduce the same entrypoint locally, use the repository's built
 
 `.env`, `.venv`, and `app/volumes/` are already ignored by `.gitignore`, so they will not be committed to GitHub.
 
+> [!TIP]
+> If your password or API key contains `$`, `\`, `#`, or `` ` ``, wrap the value in single quotes (e.g. `EPIC_PASSWORD='abc$def'`) so that `python-dotenv` does not treat `$xxx` as variable interpolation and silently drop characters. GitHub Actions Secrets are not affected.
+
 ---
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ All week-free games are already in the library
 
 `.env`、`.venv`、`app/volumes/` 都已经被 `.gitignore` 忽略，不会被提交到 GitHub。
 
+> [!TIP]
+> 如果你的密码或 API Key 含有 `$`、`\`、`#`、`` ` `` 等字符，请用单引号包起来，例如 `EPIC_PASSWORD='abc$def'`，避免 `python-dotenv` 把 `$xxx` 当成变量插值丢失字符。GitHub Actions Secrets 不受此影响。
+
 ---
 
 ## 常见问题


### PR DESCRIPTION
python-dotenv treats unquoted `$xxx` as variable interpolation. If a password or API key contains `$` followed by something that happens to be an environment variable name on the user's machine, the value will be silently mangled. Other troublesome characters: `\`, `#`, `` ` ``.

Add a one-line note to `.env.example` and the local-debug sections of both README files. GitHub Actions Secrets bypass dotenv parsing, so this only affects local runs.