### PR TITLE
Fix/claim flow modal and glm area select

### DIFF
--- a/app/extensions/llm_adapter.py
+++ b/app/extensions/llm_adapter.py
@@ -290,6 +290,13 @@ def _coerce_area_box(value: Any) -> dict[str, int] | None:
     return None
 
 
+def _box_center_point(box: dict[str, int]) -> dict[str, int]:
+    return {
+        "x": (box["x_min"] + box["x_max"]) // 2,
+        "y": (box["y_min"] + box["y_max"]) // 2,
+    }
+
+
 def _extract_area_boxes_from_text(text: str) -> list[dict[str, int]]:
     stripped = text.strip()
     if not stripped:
@@ -369,7 +376,7 @@ def _build_area_select_payload(
     return {
         "challenge_prompt": challenge_prompt,
         "inferred_rule": inferred_rule,
-        "points": boxes,
+        "points": [_box_center_point(box) for box in boxes],
     }
 
 

--- a/app/services/epic_games_service.py
+++ b/app/services/epic_games_service.py
@@ -225,30 +225,38 @@ class EpicGames:
         self._promotions: List[PromotionGame] = []
 
     @staticmethod
-    async def _locator_visible_text(locator) -> str:
+    async def _locator_visible_text(locator, timeout: int | None = None) -> str:
         with suppress(Exception):
-            return " ".join(((await locator.inner_text()) or "").upper().split())
+            options = {} if timeout is None else {"timeout": timeout}
+            return " ".join(((await locator.inner_text(**options)) or "").upper().split())
         return ""
 
     @staticmethod
-    async def _page_text(page: Page) -> str:
-        return await EpicGames._locator_visible_text(page.locator("body"))
+    async def _page_text(page: Page, timeout: int | None = None) -> str:
+        return await EpicGames._locator_visible_text(page.locator("body"), timeout=timeout)
 
     @staticmethod
-    async def _frame_texts(page: Page) -> list[str]:
+    async def _frame_texts(page: Page, timeout: int | None = None) -> list[str]:
         texts: list[str] = []
+        options = {} if timeout is None else {"timeout": timeout}
         for frame in page.frames:
             with suppress(Exception):
                 body = frame.locator("body")
-                text = await body.inner_text()
+                text = await body.inner_text(**options)
                 if text:
                     texts.append(" ".join(text.upper().split()))
         return texts
 
     @staticmethod
-    async def _combined_text(page: Page) -> str:
-        chunks = [await EpicGames._page_text(page)]
-        chunks.extend(await EpicGames._frame_texts(page))
+    async def _combined_text(
+        page: Page, timeout: int | None = None, frame_timeout: int | None = None
+    ) -> str:
+        chunks = [await EpicGames._page_text(page, timeout=timeout)]
+        chunks.extend(
+            await EpicGames._frame_texts(
+                page, timeout=frame_timeout if frame_timeout is not None else timeout
+            )
+        )
         return "\n".join(filter(None, chunks))
 
     @staticmethod
@@ -514,15 +522,9 @@ class EpicGames:
     @staticmethod
     async def _is_device_not_supported_visible(page: Page) -> bool:
         try:
-            body_text = await EpicGames._page_text(page)
+            body_text = await EpicGames._combined_text(page, timeout=500, frame_timeout=300)
         except Exception:
-            return False
-
-        if "DEVICE NOT SUPPORTED" not in body_text:
-            return False
-
-        if not ("CANCEL" in body_text and "CONTINUE" in body_text):
-            return False
+            body_text = ""
 
         candidates = [
             page.get_by_role("button", name="Continue"),
@@ -530,9 +532,18 @@ class EpicGames:
                 "//button[normalize-space(.)='Continue' or .//span[normalize-space(.)='Continue']]"
             ),
         ]
+        continue_visible = False
         for locator in candidates:
             if await EpicGames._is_locator_visible(locator, timeout=250):
-                return True
+                continue_visible = True
+                break
+
+        if "DEVICE NOT SUPPORTED" in body_text and continue_visible:
+            return True
+
+        if "NOT COMPATIBLE WITH YOUR CURRENT DEVICE" in body_text and continue_visible:
+            return True
+
         return False
 
     @staticmethod
@@ -541,9 +552,6 @@ class EpicGames:
             return True
 
         if await EpicGames._is_claimed_state(page, url):
-            return True
-
-        if await EpicGames._is_device_not_supported_visible(page):
             return True
 
         if await EpicGames._is_checkout_security_check_visible(page):
@@ -598,6 +606,14 @@ class EpicGames:
         )
 
         for name, action in click_attempts:
+            if await EpicGames._is_device_not_supported_visible(page):
+                logger.warning(
+                    "Device not supported modal blocking purchase click - dismissing before {} attempt - {}",
+                    name,
+                    url,
+                )
+                await EpicGames._handle_device_not_supported_modal(page, url, timeout_ms=5000)
+
             try:
                 await asyncio.wait_for(action(), timeout=7000)
             except Exception as err:
@@ -605,6 +621,16 @@ class EpicGames:
                 continue
 
             await page.wait_for_timeout(2500)
+
+            if await EpicGames._is_device_not_supported_visible(page):
+                logger.warning(
+                    "Device not supported modal appeared after {} click - dismissing - {}",
+                    name,
+                    url,
+                )
+                await EpicGames._handle_device_not_supported_modal(page, url, timeout_ms=5000)
+                await page.wait_for_timeout(1500)
+
             if await self._has_purchase_progress(page, url):
                 logger.debug("Purchase button {} click produced progress - {}", name, url)
                 return True
@@ -1388,6 +1414,12 @@ class EpicGames:
             # 只要不是黑名单，也不是购物车，统统当做 "Get/Purchase" 直接点击！
             # 不管它写的是 'Get', 'Free', 'Purchase', 'Buy Now'，只要 API 说是免费的，我们就点！
             logger.debug(f"⚡️ Logic: Aggressive Click (Text: {btn_text}) - {url=}")
+            if await EpicGames._is_device_not_supported_visible(page):
+                logger.warning(
+                    f"Pre-click: device not supported modal detected, dismissing first. {url=}"
+                )
+                await EpicGames._handle_device_not_supported_modal(page, url, timeout_ms=5000)
+
             if not await self._click_purchase_button(page, purchase_btn, url):
                 failed_urls.append(url)
                 continue

--- a/docs/maintenance-log.md
+++ b/docs/maintenance-log.md
@@ -455,3 +455,19 @@
 - 处理结果：
   - 在中英文 README 和 workflow 文档中补充一句直白说明。
   - 明确写出操作入口：进入 Fork 仓库的 `Actions` 页面，打开 `Epic Awesome Gamer (Scheduled)`，点击一次 `Enable workflow`。
+
+### 2026-05-05 Device not supported 弹窗阻塞购买点击
+
+- 现象：
+  - 商品页出现 `Device not supported` / 当前设备不兼容弹窗时，弹窗会挡住后续购买按钮点击。
+  - 点击流程可能在看到弹窗后仍继续尝试点击购买按钮，最终保存 `purchase_debug/click_no_effect-*.png` / `.txt`。
+- 根因判断：
+  - 设备不兼容弹窗是一个需要先点击 `Continue` 才能继续的阻塞状态，不应被当作购买流程本身的有效进展。
+  - 弹窗检测需要覆盖主页面和 frame 文本，但检测发生在点击轮询热路径中，读取 frame 文本必须带短超时，避免被默认等待时间放大。
+- 改动文件：
+  - `app/services/epic_games_service.py`
+  - `docs/maintenance-log.md`
+- 处理结果：
+  - 购买按钮点击前后都会检测并尝试关闭设备不兼容弹窗。
+  - `_has_purchase_progress()` 不再把该弹窗本身视为有效购买进展。
+  - `_combined_text()` / `_frame_texts()` 支持传入短超时，设备弹窗检测使用 500ms 主页面文本读取和 300ms frame 文本读取。

--- a/docs/maintenance-log.md
+++ b/docs/maintenance-log.md
@@ -471,3 +471,20 @@
   - 购买按钮点击前后都会检测并尝试关闭设备不兼容弹窗。
   - `_has_purchase_progress()` 不再把该弹窗本身视为有效购买进展。
   - `_combined_text()` / `_frame_texts()` 支持传入短超时，设备弹窗检测使用 500ms 主页面文本读取和 300ms frame 文本读取。
+
+### 2026-05-05 GLM 框坐标导致 hCaptcha 点选解析失败
+
+- 现象：
+  - 登录 hCaptcha `image_label_multi_select` / `image_label_area_select` 流程中，GLM 返回 `{"answer":[[x_min,y_min,x_max,y_max], ...]}`。
+  - `ImageAreaSelectChallenge` 校验时报 `points.*.x` / `points.*.y` 缺失，最终触发 `RetryError`。
+- 根因判断：
+  - 上游 `ImageAreaSelectChallenge.points` 只接受点击点坐标 `{"x": ..., "y": ...}`。
+  - GLM 兼容层只要求模型返回 JSON，模型可能用视觉检测常见的框坐标格式回答。
+  - 适配层已经识别了框坐标，但错误地把 `x_min/y_min/x_max/y_max` 原样塞入 `points`。
+- 改动文件：
+  - `app/extensions/llm_adapter.py`
+  - `tests/test_glm_adapter.py`
+  - `docs/maintenance-log.md`
+- 处理结果：
+  - GLM 返回框坐标时，适配层会转成矩形中心点击点后再构造 `ImageAreaSelectChallenge`。
+  - 增加回归测试覆盖数组框坐标和对象框坐标两种返回格式。

--- a/tests/test_glm_adapter.py
+++ b/tests/test_glm_adapter.py
@@ -1,0 +1,41 @@
+import json
+
+from hcaptcha_challenger.models import ImageAreaSelectChallenge
+
+from extensions.llm_adapter import (
+    _coerce_payload_for_schema,
+    _extract_json_payload,
+    _normalize_glm_payload,
+)
+
+
+def test_area_select_box_answer_is_converted_to_click_points():
+    text = '{"answer":[[781,525,889,624],[1031,525,1139,624]]}'
+
+    payload = _coerce_payload_for_schema(
+        _normalize_glm_payload(_extract_json_payload(text)), ImageAreaSelectChallenge, text
+    )
+    challenge = ImageAreaSelectChallenge(**payload)
+
+    assert challenge.points[0].model_dump() == {"x": 835, "y": 574}
+    assert challenge.points[1].model_dump() == {"x": 1085, "y": 574}
+
+
+def test_area_select_dict_boxes_are_converted_to_click_points():
+    payload = {
+        "answer": [
+            {"x_min": 10, "y_min": 20, "x_max": 30, "y_max": 60},
+            {"x_min": 101, "y_min": 201, "x_max": 200, "y_max": 300},
+        ]
+    }
+    text = json.dumps(payload)
+
+    coerced = _coerce_payload_for_schema(
+        _normalize_glm_payload(payload), ImageAreaSelectChallenge, text
+    )
+    challenge = ImageAreaSelectChallenge(**coerced)
+
+    assert [point.model_dump() for point in challenge.points] == [
+        {"x": 20, "y": 40},
+        {"x": 150, "y": 250},
+    ]


### PR DESCRIPTION
## Summary

  This PR fixes two issues in the Epic claim and login flows:

  1. Handle the `Device not supported` modal as a blocking state during purchase clicks.
  2. Convert GLM hCaptcha area-select box outputs into click-point payloads expected by
  `ImageAreaSelectChallenge`.

  ## Changes

  - Dismiss the `Device not supported` / current-device-incompatible modal before and after purchase
  button clicks.
  - Stop treating the device-incompatible modal itself as valid purchase progress.
  - Add short timeout support to `_combined_text()` and `_frame_texts()` so modal detection can scan page
  and frame text without inflating click-loop wait time.
  - Convert GLM area box coordinates (`x_min/y_min/x_max/y_max`) into rectangle-center click points
  before building the area-select payload.
  - Add regression coverage for both array-style and object-style GLM box outputs.
  - Append both maintenance entries to `docs/maintenance-log.md`.

  ## Why

  On some product pages, the compatibility modal overlays the purchase button and absorbs clicks, which
  leads to repeated "click no effect" debug captures without actual purchase progress.

  In the login hCaptcha area-select flow, GLM may return bounding boxes instead of click points. The
  upstream challenge model only accepts `{"x": ..., "y": ...}` points, so passing raw box coordinates
  caused validation failure and eventually `RetryError`.

  ## Files

  - `app/services/epic_games_service.py`
  - `app/extensions/llm_adapter.py`
  - `tests/test_glm_adapter.py`
  - `docs/maintenance-log.md`
