### PR TITLE
Add multi-account support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@
 EPIC_EMAIL=xxxx@qq.com
 EPIC_PASSWORD=mypassword
 
+# Multi-account support (optional, overrides EPIC_EMAIL/EPIC_PASSWORD)
+# For GitHub Actions Secrets, create EPIC_ACCOUNTS as a multiline secret:
+# user1@example.com:password1
+# user2@example.com:password2
+#
+# For local .env files, keep using EPIC_EMAIL/EPIC_PASSWORD unless your
+# dotenv parser supports multiline values.
+
 # LLM provider
 # Supported values: gemini, glm
 # Keep this in sync with the key you actually fill below:

--- a/.github/workflows/epic-gamer.yml
+++ b/.github/workflows/epic-gamer.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           EPIC_EMAIL: ${{ secrets.EPIC_EMAIL }}
           EPIC_PASSWORD: ${{ secrets.EPIC_PASSWORD }}
+          EPIC_ACCOUNTS: ${{ secrets.EPIC_ACCOUNTS }}
           LLM_PROVIDER: ${{ secrets.LLM_PROVIDER }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_BASE_URL: ${{ secrets.GEMINI_BASE_URL }}

--- a/README.en.md
+++ b/README.en.md
@@ -82,12 +82,20 @@ After forking, open the `Actions` page in your fork, enter `Epic Awesome Gamer (
 
 Go to `Settings` -> `Secrets and variables` -> `Actions`.
 
-Required in all cases:
+Account configuration (choose one):
+
+**Single account:**
 
 | Secret | Example value |
 | --- | --- |
 | `EPIC_EMAIL` | your_epic_email@example.com |
 | `EPIC_PASSWORD` | your_epic_password |
+
+**Multiple accounts:**
+
+| Secret | Example value |
+| --- | --- |
+| `EPIC_ACCOUNTS` | One account per line, format: `email:password` |
 
 If you use `GLM`, start with this set:
 
@@ -148,6 +156,32 @@ If you do want to override those four model fields explicitly, use values like t
 | `IMAGE_CLASSIFIER_MODEL` | empty or `glm-4.6v` | empty or `gemini-2.5-pro` |
 | `SPATIAL_POINT_REASONER_MODEL` | empty or `glm-4.6v` | empty or `gemini-2.5-pro` |
 | `SPATIAL_PATH_REASONER_MODEL` | empty or `glm-4.6v` | empty or `gemini-2.5-pro` |
+
+### Multi-account support (optional)
+
+If you have multiple Epic accounts, you can manage them all in a single Secret without forking the repo multiple times.
+
+Go to `Settings` -> `Secrets and variables` -> `Actions` and create a new Secret:
+
+| Secret | Value |
+| --- | --- |
+| `EPIC_ACCOUNTS` | One account per line, format: `email:password` |
+
+Example:
+
+```text
+user1@example.com:password1
+user2@example.com:password2
+user3@example.com:password3
+```
+
+Notes:
+
+- When `EPIC_ACCOUNTS` is set, `EPIC_EMAIL` / `EPIC_PASSWORD` are ignored.
+- If `EPIC_ACCOUNTS` is not set, the original single-account mode is used (fully backward compatible).
+- Each account runs independently: one account's failure does not affect the others.
+- Each account automatically gets its own isolated browser profile directory.
+- If a password contains a colon `:`, only the first colon is used as the separator.
 
 ### 3. Run the workflow manually once
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,20 @@ Fork 之后先打开自己仓库的 `Actions` 页面，进入 `Epic Awesome Game
 
 进入 `Settings` -> `Secrets and variables` -> `Actions`。
 
-必须配置：
+账号配置（二选一）：
+
+**单账号：**
 
 | Secret | 示例值 |
 | --- | --- |
 | `EPIC_EMAIL` | your_epic_email@example.com |
 | `EPIC_PASSWORD` | your_epic_password |
+
+**多账号：**
+
+| Secret | 示例值 |
+| --- | --- |
+| `EPIC_ACCOUNTS` | 每行一个账号，格式为 `邮箱:密码` |
 
 如果你使用 `GLM`，建议先按下面这组填写：
 
@@ -147,6 +155,32 @@ Fork 之后先打开自己仓库的 `Actions` 页面，进入 `Epic Awesome Game
 | `IMAGE_CLASSIFIER_MODEL` | 留空或 `glm-4.6v` | 留空或 `gemini-2.5-pro` |
 | `SPATIAL_POINT_REASONER_MODEL` | 留空或 `glm-4.6v` | 留空或 `gemini-2.5-pro` |
 | `SPATIAL_PATH_REASONER_MODEL` | 留空或 `glm-4.6v` | 留空或 `gemini-2.5-pro` |
+
+### 多账号配置（可选）
+
+如果你有多个 Epic 账号，可以用一个 Secret 同时管理，无需多次 Fork。
+
+进入 `Settings` -> `Secrets and variables` -> `Actions`，新建一个 Secret：
+
+| Secret | 值 |
+| --- | --- |
+| `EPIC_ACCOUNTS` | 每行一个账号，格式为 `邮箱:密码` |
+
+示例：
+
+```text
+user1@example.com:password1
+user2@example.com:password2
+user3@example.com:password3
+```
+
+说明：
+
+- 设置 `EPIC_ACCOUNTS` 后，会自动忽略 `EPIC_EMAIL` / `EPIC_PASSWORD`。
+- 如果不设置 `EPIC_ACCOUNTS`，仍然走原来的单账号模式，完全向后兼容。
+- 每个账号独立运行：一个账号失败不影响其他账号。
+- 每个账号自动使用独立的浏览器配置目录，互不干扰。
+- 密码中如果包含冒号 `:`，只会按第一个冒号分割，不会误判。
 
 ### 3. 手动运行一次
 

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Multi-account support for Epic Games freebies helper.
+
+Supports two input formats:
+  1. EPIC_ACCOUNTS: multiline env var, one "email:password" per line (recommended)
+  2. EPIC_EMAIL + EPIC_PASSWORD: single account fallback (backward compatible)
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from loguru import logger
+from pydantic import SecretStr
+
+
+def mask_email(email: str) -> str:
+    """Mask an email address before writing it to logs."""
+    local, separator, domain = email.partition("@")
+    if not separator:
+        return "***"
+
+    masked_local = f"{local[:2]}***" if len(local) > 2 else f"{local[:1]}***"
+    return f"{masked_local}@{domain}"
+
+
+def parse_accounts() -> List[Tuple[str, str]]:
+    """
+    Parse account credentials from settings.
+
+    Priority:
+      1. EPIC_ACCOUNTS (multiline, one "email:password" per line)
+      2. EPIC_EMAIL + EPIC_PASSWORD (single account fallback)
+
+    Returns:
+        List of (email, password) tuples.
+    """
+    from settings import settings
+
+    # --- Priority 1: EPIC_ACCOUNTS multiline env var ---
+    raw = ""
+    if settings.EPIC_ACCOUNTS is not None:
+        raw = settings.EPIC_ACCOUNTS.get_secret_value().strip()
+
+    if raw:
+        accounts: List[Tuple[str, str]] = []
+        for i, line in enumerate(raw.splitlines(), 1):
+            line = line.strip()
+            if not line:
+                continue
+
+            # Split on first colon only (passwords may contain colons)
+            if ":" not in line:
+                logger.warning(
+                    "EPIC_ACCOUNTS line {} skipped: missing colon separator (email:password)", i
+                )
+                continue
+
+            email, password = line.split(":", 1)
+            email = email.strip()
+            password = password.strip()
+
+            if not email or not password:
+                logger.warning("EPIC_ACCOUNTS line {} skipped: empty email or password", i)
+                continue
+
+            accounts.append((email, password))
+
+        if accounts:
+            logger.info("Parsed {} account(s) from EPIC_ACCOUNTS", len(accounts))
+            return accounts
+
+        logger.warning("EPIC_ACCOUNTS is set but no valid entries found")
+        return []
+
+    # --- Priority 2: EPIC_EMAIL + EPIC_PASSWORD (single account) ---
+    email = (settings.EPIC_EMAIL or "").strip()
+    password = settings.EPIC_PASSWORD.get_secret_value().strip()
+
+    if email and password:
+        logger.info("Using single account from EPIC_EMAIL/EPIC_PASSWORD")
+        return [(email, password)]
+
+    return []
+
+
+def swap_account(email: str, password: str) -> None:
+    """Swap the active account credentials on the global settings object."""
+    from settings import settings
+
+    settings.EPIC_EMAIL = email
+    settings.EPIC_PASSWORD = SecretStr(password)
+
+    logger.info("Switched to account: {}", mask_email(email))

--- a/app/deploy.py
+++ b/app/deploy.py
@@ -22,6 +22,7 @@ from apscheduler.triggers.cron import CronTrigger
 from loguru import logger
 from pytz import timezone
 
+from accounts import mask_email, parse_accounts, swap_account
 from services.epic_authorization_service import EpicAuthorization
 from services.browser_context import open_browser_context
 from services.epic_games_service import EpicAgent
@@ -90,6 +91,47 @@ async def execute_browser_tasks(headless: bool = True):
         logger.debug("Browser tasks execution finished successfully")
 
 
+async def _run_accounts(headless: bool) -> None:
+    """Run collection tasks for all configured accounts."""
+    accounts = parse_accounts()
+    if not accounts:
+        raise RuntimeError(
+            "No accounts configured. Set EPIC_ACCOUNTS (multiline email:password) "
+            "or EPIC_EMAIL + EPIC_PASSWORD."
+        )
+
+    total = len(accounts)
+    succeeded = 0
+    failed_accounts: list[str] = []
+
+    for index, (email, password) in enumerate(accounts, 1):
+        masked_email = mask_email(email)
+        logger.info("=" * 60)
+        logger.info("Processing account {}/{}: {}", index, total, masked_email)
+        logger.info("=" * 60)
+
+        try:
+            swap_account(email, password)
+            await execute_browser_tasks(headless=headless)
+            succeeded += 1
+            logger.success("Account {}/{} completed: {}", index, total, masked_email)
+        except Exception as err:
+            failed_accounts.append(masked_email)
+            logger.error("Account {}/{} failed: {} | error: {}", index, total, masked_email, err)
+            # Continue to next account — don't abort the entire run
+
+    # Summary
+    logger.info("=" * 60)
+    logger.info("Multi-account run summary: {}/{} succeeded", succeeded, total)
+    if failed_accounts:
+        logger.warning("Failed accounts: {}", ", ".join(failed_accounts))
+        raise RuntimeError(
+            f"{len(failed_accounts)} of {total} account(s) failed: "
+            + ", ".join(failed_accounts)
+        )
+    logger.success("All {} account(s) completed successfully", total)
+
+
 async def deploy():
     """
     Main deployment function that executes Epic Games collection tasks.
@@ -110,8 +152,8 @@ async def deploy():
         logger.error(configuration_error)
         raise RuntimeError(configuration_error)
 
-    # Execute an immediate collection task
-    await execute_browser_tasks(headless=headless)
+    # Execute collection tasks for all configured accounts
+    await _run_accounts(headless=headless)
 
     # Skip scheduler setup if disabled in configuration
     if not settings.ENABLE_APSCHEDULER:
@@ -123,7 +165,7 @@ async def deploy():
 
     # Strategy 1: Thursday 23:30 to Friday 03:30, every hour (Beijing Time)
     scheduler.add_job(
-        execute_browser_tasks,
+        _run_accounts,
         trigger=CronTrigger(
             day_of_week="thu", hour="23,0,1,2,3", minute="30", timezone="Asia/Shanghai"
         ),
@@ -136,7 +178,7 @@ async def deploy():
 
     # Strategy 2: Daily at 12:00 PM (Beijing Time)
     scheduler.add_job(
-        execute_browser_tasks,
+        _run_accounts,
         trigger=CronTrigger(hour="12", minute="0", timezone="Asia/Shanghai"),
         id="daily_epic_games_task",
         name="daily_epic_games_task",

--- a/app/settings.py
+++ b/app/settings.py
@@ -64,8 +64,11 @@ class EpicSettings(AgentConfig):
         default="auto", description="Supported values: auto, camoufox, playwright"
     )
 
-    EPIC_EMAIL: str = Field(default_factory=lambda: _env("EPIC_EMAIL"))
-    EPIC_PASSWORD: SecretStr = Field(default_factory=lambda: _env("EPIC_PASSWORD"))
+    EPIC_ACCOUNTS: SecretStr | None = Field(
+        default=None, description="Optional multiline email:password account list"
+    )
+    EPIC_EMAIL: str = Field(default_factory=lambda: _env("EPIC_EMAIL", ""))
+    EPIC_PASSWORD: SecretStr = Field(default_factory=lambda: _env("EPIC_PASSWORD", ""))
     DISABLE_BEZIER_TRAJECTORY: bool = Field(default=False)
     WAIT_FOR_CHALLENGE_VIEW_TO_RENDER_MS: int = Field(default=3000)
 


### PR DESCRIPTION
## Summary

- Add EPIC_ACCOUNTS multiline configuration for running multiple Epic accounts in one workflow run
- Keep EPIC_EMAIL / EPIC_PASSWORD as the backward-compatible single-account fallback
- Run accounts sequentially with isolated browser profiles and masked account emails in logs
- Document multi-account setup in Chinese and English README files

## Verification

- Syntax check passed for modified Python files:
  - app/accounts.py
  - app/deploy.py
  - app/settings.py
- Project test suite was not run.